### PR TITLE
Add new label titles phone phone and email

### DIFF
--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -474,13 +474,13 @@ public class ContactsManager extends ReactContextBaseJavaModule {
     private int mapStringToPhoneType(String label) {
         int phoneType;
         switch (label) {
-            case "home":
-                phoneType = CommonDataKinds.Phone.TYPE_HOME;
-                break;
-            case "work":
+            case "phone":
                 phoneType = CommonDataKinds.Phone.TYPE_WORK;
                 break;
-            case "mobile":
+            case "fax":
+                phoneType = CommonDataKinds.Phone.TYPE_FAX_WORK;
+                break;
+            case "cell":
                 phoneType = CommonDataKinds.Phone.TYPE_MOBILE;
                 break;
             default:
@@ -500,7 +500,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
             case "home":
                 emailType = CommonDataKinds.Email.TYPE_HOME;
                 break;
-            case "work":
+            case "email":
                 emailType = CommonDataKinds.Email.TYPE_WORK;
                 break;
             case "mobile":


### PR DESCRIPTION
 This PR adds new titles for android phone numbers and emails. Android has a particular type for phone numbers and email, this lib was setup for titles that do not match our object keys.  Work with Bickham with naming the ones we need at this point.

Please note that the strings/object keys passed into the java are not hard coded.